### PR TITLE
Mirror of netflix vmaf#167

### DIFF
--- a/wrapper/src/combo.c
+++ b/wrapper/src/combo.c
@@ -33,6 +33,7 @@
 #include "darray.h"
 #include "adm_options.h"
 #include "combo.h"
+#include "debug.h"
 
 #ifdef MULTI_THREADING
 #include "common/blur_array.h"
@@ -161,7 +162,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
         {
             // this is the signal that another thread has reached the end of the input file, so we all quit
             pthread_mutex_unlock(&thread_data->mutex_readframe);
-            break;
+            goto fail_or_end;
         }
 #endif
 
@@ -177,18 +178,18 @@ void* combo_threadfunc(void* vmaf_thread_data)
             if (ret == 1)
             {
 #ifdef MULTI_THREADING
-            thread_data->stop_threads = 1;
-            pthread_mutex_unlock(&thread_data->mutex_readframe);
+                thread_data->stop_threads = 1;
+                pthread_mutex_unlock(&thread_data->mutex_readframe);
 #endif
                 goto fail_or_end;
             }
             if (ret == 2)
             {
 #ifdef MULTI_THREADING
-            thread_data->stop_threads = 1;
-            pthread_mutex_unlock(&thread_data->mutex_readframe);
+                thread_data->stop_threads = 1;
+                pthread_mutex_unlock(&thread_data->mutex_readframe);
 #endif
-                break;
+                goto fail_or_end;
             }
 
             // ===============================================================
@@ -242,7 +243,6 @@ void* combo_threadfunc(void* vmaf_thread_data)
         {
 #ifdef MULTI_THREADING
             thread_data->stop_threads = 1;
-            pthread_mutex_unlock(&thread_data->mutex_readframe);
 #endif
             next_frame_read = false;
         }
@@ -279,10 +279,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
 #endif
         }
 
-
-#ifdef PRINT_PROGRESS
-        printf("frame: %d, ", frm_idx);
-#endif
+        dbg_printf("frame: %d, ", frm_idx);
 
         // ===============================================================
         // for the PSNR, SSIM and MS-SSIM, offset are 0. Since in prev read
@@ -303,9 +300,8 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 goto fail_or_end;
             }
 
-#ifdef PRINT_PROGRESS
-            printf("psnr: %.3f, ", score);
-#endif
+            dbg_printf("psnr: %.3f, ", score);
+
             insert_array_at(thread_data->psnr_array, score, frm_idx);
         }
 
@@ -319,9 +315,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 goto fail_or_end;
             }
 
-#ifdef PRINT_PROGRESS
-            printf("ssim: %.3f, ", score);
-#endif
+            dbg_printf("ssim: %.3f, ", score);
 
             insert_array_at(thread_data->ssim_array, score, frm_idx);
         }
@@ -335,9 +329,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 goto fail_or_end;
             }
 
-#ifdef PRINT_PROGRESS
-            printf("ms_ssim: %.3f, ", score);
-#endif
+            dbg_printf("ms_ssim: %.3f, ", score);
 
             insert_array_at(thread_data->ms_ssim_array, score, frm_idx);
         }
@@ -357,19 +349,17 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 goto fail_or_end;
             }
 
-#ifdef PRINT_PROGRESS
-            printf("adm: %.3f, ", score);
-            printf("adm_num: %.3f, ", score_num);
-            printf("adm_den: %.3f, ", score_den);
-            printf("adm_num_scale0: %.3f, ", scores[0]);
-            printf("adm_den_scale0: %.3f, ", scores[1]);
-            printf("adm_num_scale1: %.3f, ", scores[2]);
-            printf("adm_den_scale1: %.3f, ", scores[3]);
-            printf("adm_num_scale2: %.3f, ", scores[4]);
-            printf("adm_den_scale2: %.3f, ", scores[5]);
-            printf("adm_num_scale3: %.3f, ", scores[6]);
-            printf("adm_den_scale3: %.3f, ", scores[7]);
-#endif
+            dbg_printf("adm: %.3f, ", score);
+            dbg_printf("adm_num: %.3f, ", score_num);
+            dbg_printf("adm_den: %.3f, ", score_den);
+            dbg_printf("adm_num_scale0: %.3f, ", scores[0]);
+            dbg_printf("adm_den_scale0: %.3f, ", scores[1]);
+            dbg_printf("adm_num_scale1: %.3f, ", scores[2]);
+            dbg_printf("adm_den_scale1: %.3f, ", scores[3]);
+            dbg_printf("adm_num_scale2: %.3f, ", scores[4]);
+            dbg_printf("adm_den_scale2: %.3f, ", scores[5]);
+            dbg_printf("adm_num_scale3: %.3f, ", scores[6]);
+            dbg_printf("adm_den_scale3: %.3f, ", scores[7]);
 
             insert_array_at(thread_data->adm_num_array, score_num, frm_idx);
             insert_array_at(thread_data->adm_den_array, score_den, frm_idx);
@@ -410,10 +400,8 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 goto fail_or_end;
             }
 
-#ifdef PRINT_PROGRESS
-            printf("ansnr: %.3f, ", score);
-            printf("anpsnr: %.3f, ", score_psnr);
-#endif
+            dbg_printf("ansnr: %.3f, ", score);
+            dbg_printf("anpsnr: %.3f, ", score_psnr);
         }
 
 #endif
@@ -462,10 +450,8 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 }
             }
 
-#ifdef PRINT_PROGRESS
-            printf("motion: %.3f, ", score);
-            printf("motion2: %.3f, ", score2);
-#endif
+            dbg_printf("motion: %.3f, ", score);
+            dbg_printf("motion2: %.3f, ", score2);
 
             insert_array_at(thread_data->motion_array, score, frm_idx);
             insert_array_at(thread_data->motion2_array, score2, frm_idx);
@@ -496,19 +482,17 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 goto fail_or_end;
             }
 
-#ifdef PRINT_PROGRESS
-            // printf("vif_num: %.3f, ", score_num);
-            // printf("vif_den: %.3f, ", score_den);
-            printf("vif_num_scale0: %.3f, ", scores[0]);
-            printf("vif_den_scale0: %.3f, ", scores[1]);
-            printf("vif_num_scale1: %.3f, ", scores[2]);
-            printf("vif_den_scale1: %.3f, ", scores[3]);
-            printf("vif_num_scale2: %.3f, ", scores[4]);
-            printf("vif_den_scale2: %.3f, ", scores[5]);
-            printf("vif_num_scale3: %.3f, ", scores[6]);
-            printf("vif_den_scale3: %.3f, ", scores[7]);
-            printf("vif: %.3f, ", score);
-#endif
+            // dbg_printf("vif_num: %.3f, ", score_num);
+            // dbg_printf("vif_den: %.3f, ", score_den);
+            dbg_printf("vif_num_scale0: %.3f, ", scores[0]);
+            dbg_printf("vif_den_scale0: %.3f, ", scores[1]);
+            dbg_printf("vif_num_scale1: %.3f, ", scores[2]);
+            dbg_printf("vif_den_scale1: %.3f, ", scores[3]);
+            dbg_printf("vif_num_scale2: %.3f, ", scores[4]);
+            dbg_printf("vif_den_scale2: %.3f, ", scores[5]);
+            dbg_printf("vif_num_scale3: %.3f, ", scores[6]);
+            dbg_printf("vif_den_scale3: %.3f, ", scores[7]);
+            dbg_printf("vif: %.3f, ", score);
 
             insert_array_at(thread_data->vif_num_scale0_array, scores[0], frm_idx);
             insert_array_at(thread_data->vif_den_scale0_array, scores[1], frm_idx);
@@ -521,9 +505,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
             insert_array_at(thread_data->vif_array, score, frm_idx);
         }
 
-#ifdef PRINT_PROGRESS
-        printf("\n");
-#endif
+        dbg_printf("\n");
 
 #ifndef MULTI_THREADING
         // copy to prev_buf
@@ -537,7 +519,6 @@ void* combo_threadfunc(void* vmaf_thread_data)
         {
 #ifdef MULTI_THREADING
             thread_data->stop_threads = 1;
-            pthread_mutex_unlock(&thread_data->mutex_readframe);
 #endif
             break;
         }
@@ -684,7 +665,7 @@ int combo(int (*read_frame)(float *ref_data, float *main_data, float *temp_data,
     // start threads
     int t;
     pthread_t thread[combo_thread_data.thread_count];
-    for (t=0; t<combo_thread_data.thread_count; t++)
+    for (t=0; t < combo_thread_data.thread_count; t++)
     {
         pthread_create(&thread[t], &attr, combo_threadfunc, &combo_thread_data);
     }
@@ -692,7 +673,7 @@ int combo(int (*read_frame)(float *ref_data, float *main_data, float *temp_data,
     pthread_attr_destroy(&attr);
 
     // wait for all threads to finish
-    for (t=0; t<combo_thread_data.thread_count; t++)
+    for (t=0; t < combo_thread_data.thread_count; t++)
     {
         void* thread_ret;
         int rc = pthread_join(thread[t], &thread_ret);

--- a/wrapper/src/debug.h
+++ b/wrapper/src/debug.h
@@ -1,0 +1,28 @@
+/**
+ *
+ *  Copyright 2016-2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef DEBUG_H_
+#define DEBUG_H_
+
+#if PRINT_PROGRESS
+  #define dbg_printf(...) printf(__VA_ARGS__)
+#else
+  #define dbg_printf(...) (0)
+#endif
+
+#endif /* DEBUG_H_ */

--- a/wrapper/src/vmaf.cpp
+++ b/wrapper/src/vmaf.cpp
@@ -34,6 +34,7 @@
 #include "timer.h"
 #include "chooseser.h"
 #include "jsonprint.h"
+#include "debug.h"
 
 #define VAL_EQUAL_STR(V,S) (Stringize((V)).compare((S))==0)
 #define VAL_IS_LIST(V) ((V).tag=='n') /* check ocval.cc */
@@ -142,16 +143,12 @@ Result VmafRunner::run(Asset asset, int (*read_frame)(float *ref_data, float *ma
                        bool do_psnr, bool do_ssim, bool do_ms_ssim, int n_thread, int n_subsample)
 {
 
-#ifdef PRINT_PROGRESS
-    printf("Read input model (pkl)...\n");
-#endif
+    dbg_printf("Read input model (pkl)...\n");
 
     Val feature_names, norm_type, slopes, intercepts, score_clip, score_transform;
     _read_and_assert_model(model_path, feature_names, norm_type, slopes, intercepts, score_clip, score_transform);
 
-#ifdef PRINT_PROGRESS
-    printf("Read input model (libsvm)...\n");
-#endif
+    dbg_printf("Read input model (libsvm)...\n");
 
     std::unique_ptr<svm_model, SvmDelete> svm_model_ptr{svm_load_model(libsvm_model_path)};
     if (!svm_model_ptr)
@@ -160,9 +157,7 @@ Result VmafRunner::run(Asset asset, int (*read_frame)(float *ref_data, float *ma
         throw VmafException("Error loading SVM model");
     }
 
-#ifdef PRINT_PROGRESS
-    printf("Initialize storage arrays...\n");
-#endif
+    dbg_printf("Initialize storage arrays...\n");
 
     int w = asset.getWidth();
     int h = asset.getHeight();
@@ -250,9 +245,7 @@ Result VmafRunner::run(Asset asset, int (*read_frame)(float *ref_data, float *ma
         ms_ssim_array_ptr = NULL;
     }
 
-#ifdef PRINT_PROGRESS
-    printf("Extract atom features...\n");
-#endif
+    dbg_printf("Extract atom features...\n");
 
     int ret = combo(read_frame, user_data, w, h, fmt,
             &adm_num_array,
@@ -352,9 +345,7 @@ Result VmafRunner::run(Asset asset, int (*read_frame)(float *ref_data, float *ma
         throw VmafException(errmsg);
     }
 
-#ifdef PRINT_PROGRESS
-    printf("Generate final features (including derived atom features)...\n");
-#endif
+    dbg_printf("Generate final features (including derived atom features)...\n");
 
     double ADM2_CONSTANT = 0.0;
     double ADM_SCALE_CONSTANT = 0.0;
@@ -384,9 +375,7 @@ Result VmafRunner::run(Asset asset, int (*read_frame)(float *ref_data, float *ma
         }
     }
 
-#ifdef PRINT_PROGRESS
-    printf("Normalize features, SVM regression, denormalize score, clip...\n");
-#endif
+    dbg_printf("Normalize features, SVM regression, denormalize score, clip...\n");
 
     /* IMPORTANT: always allocate one more spot and put a -1 at the last one's
      * index, so that libsvm will stop looping when seeing the -1 !!!
@@ -541,28 +530,26 @@ Result VmafRunner::run(Asset asset, int (*read_frame)(float *ref_data, float *ma
             //        node[0].value, node[1].value, node[2].value,
             //        node[3].value, node[4].value, node[5].value, prediction);
 
-#ifdef PRINT_PROGRESS
-            printf("frame: %zu, ", i);
-            printf("vmaf: %f, ", prediction);
-            printf("adm2: %f, ", adm2.at(i / n_subsample));
-            printf("adm_scale0: %f, ", adm_scale0.at(i / n_subsample));
-            printf("adm_scale1: %f, ", adm_scale1.at(i / n_subsample));
-            printf("adm_scale2: %f, ", adm_scale2.at(i / n_subsample));
-            printf("adm_scale3: %f, ", adm_scale3.at(i / n_subsample));
-            printf("motion: %f, ", motion.at(i / n_subsample));
-            printf("vif_scale0: %f, ", vif_scale0.at(i / n_subsample));
-            printf("vif_scale1: %f, ", vif_scale1.at(i / n_subsample));
-            printf("vif_scale2: %f, ", vif_scale2.at(i / n_subsample));
-            printf("vif_scale3: %f, ", vif_scale3.at(i / n_subsample));
-            printf("vif: %f, ", vif.at(i / n_subsample));
-            printf("motion2: %f, ", motion2.at(i / n_subsample));
+            dbg_printf("frame: %zu, ", i);
+            dbg_printf("vmaf: %f, ", prediction);
+            dbg_printf("adm2: %f, ", adm2.at(i / n_subsample));
+            dbg_printf("adm_scale0: %f, ", adm_scale0.at(i / n_subsample));
+            dbg_printf("adm_scale1: %f, ", adm_scale1.at(i / n_subsample));
+            dbg_printf("adm_scale2: %f, ", adm_scale2.at(i / n_subsample));
+            dbg_printf("adm_scale3: %f, ", adm_scale3.at(i / n_subsample));
+            dbg_printf("motion: %f, ", motion.at(i / n_subsample));
+            dbg_printf("vif_scale0: %f, ", vif_scale0.at(i / n_subsample));
+            dbg_printf("vif_scale1: %f, ", vif_scale1.at(i / n_subsample));
+            dbg_printf("vif_scale2: %f, ", vif_scale2.at(i / n_subsample));
+            dbg_printf("vif_scale3: %f, ", vif_scale3.at(i / n_subsample));
+            dbg_printf("vif: %f, ", vif.at(i / n_subsample));
+            dbg_printf("motion2: %f, ", motion2.at(i / n_subsample));
 
-            if (psnr_array_ptr != NULL) { printf("psnr: %f, ", psnr.at(i / n_subsample)); }
-            if (ssim_array_ptr != NULL) { printf("ssim: %f, ", ssim.at(i / n_subsample)); }
-            if (ms_ssim_array_ptr != NULL) { printf("ms_ssim: %f, ", ms_ssim.at(i / n_subsample)); }
+            if (psnr_array_ptr != NULL) { dbg_printf("psnr: %f, ", psnr.at(i / n_subsample)); }
+            if (ssim_array_ptr != NULL) { dbg_printf("ssim: %f, ", ssim.at(i / n_subsample)); }
+            if (ms_ssim_array_ptr != NULL) { dbg_printf("ms_ssim: %f, ", ms_ssim.at(i / n_subsample)); }
 
-            printf("\n");
-#endif
+            dbg_printf("\n");
 
             vmaf.append(prediction);
         }


### PR DESCRIPTION
Mirror of netflix vmaf#167
Fix a thread lock situation detected in vmafossexec (at least when running in MacOS). It happens quite infrequently (1 of 30 approx) but it is there and is easy to reproduce for longer files. This PR modifies `combo_threadfunc` function of `combo.c` to remove `pthread_mutex_unlock` operations that were done over an already unlocked mutex. After applying this change I couldn't reproduce the thread lock anymore.

I took advantage of this change to create a macro for printing progress while keeping the possibility of activating/deactivating it through a preprocessor define (`PRINT_PROGRESS`). Just to keep code easy to read.
